### PR TITLE
fix(bigint) throw large numbers

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -8,6 +8,10 @@ const traverseObject = <T extends object>(
   parentKey: string,
   separator: string
 ) => {
+  if(typeof value === 'number' && obj > Number.MAX_SAFE_INTEGER) {
+    throw new Error('Do not know how to serialize a BigInt')
+  }
+  
   const childKeys = Object.keys(obj);
 
   if (childKeys.length === 0) {


### PR DESCRIPTION
Big Ints are silently transformed, this throws them out as invalid, which propagates up to the UI. Not sure if it's the most desirable but its one possible approach, a better one being support for BigInt.

Inspired by https://github.com/Kong/insomnia/issues/2951


Alternatively https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#use_within_json

`BigInt.prototype.toJSON = function() { return this.toString()  }`

This alternative would be best implemented as a plugin.