### PR TITLE
Some keys are being excluded during `order`

### DIFF
--- a/__tests__/order.test.ts
+++ b/__tests__/order.test.ts
@@ -7,7 +7,7 @@ describe('order()', () => {
     obj: T,
     map: PropertyMap | null,
     res: T
-  ) => expect(order(obj, map, '.')).toEqual(res);
+  ) => expect(JSON.stringify(order(obj, map, '.'))).toEqual(JSON.stringify(res));
 
   it('returns nothing for a blank JSON string', () => expectObject({}, {}, {}));
 

--- a/__tests__/order.test.ts
+++ b/__tests__/order.test.ts
@@ -163,4 +163,45 @@ describe('order()', () => {
       },
       {i: 7, a: {b: [8, {d: [{f: {h: 'h', g: true}, e: 12}, 10], c: 9}, 11]}}
     ));
+  
+  it('sorts keys with special characters', () => {
+    const obj = {
+      'lint-staged': {
+        '**/src/**/*.{js,jsx,ts,tsx}': 'eslint --fix'
+      },
+      dependencies: {
+        a: '1.2.3',
+        z: '1.2.3',
+        '@types/a': '1.2.3',
+        '@types/z': '1.2.3',
+        '@types/b': '1.2.3',
+      },
+    };
+    const map = {
+      '$': ['dependencies', 'lint-staged'],
+      '$.dependencies':(() => {
+        const keys = Object.keys(obj.dependencies);
+
+        // sort keys naturally
+        keys.sort();
+
+        return keys;
+      })(),
+      '$.lint-staged': Object.keys(obj['lint-staged']),
+    };
+    const expected = {
+      dependencies: {
+        '@types/a': '1.2.3',
+        '@types/b': '1.2.3',
+        '@types/z': '1.2.3',
+        a: '1.2.3',
+        z: '1.2.3',
+      },
+      'lint-staged': {
+        '**/src/**/*.{js,jsx,ts,tsx}': 'eslint --fix'
+      },
+    };
+
+    expectObject(obj, map, expected);
+  });
 });


### PR DESCRIPTION
This PR adds a test to illustrate the problem but does not (yet) provide a fix.

Note that the `expectObject` function in `__tests__/order.test.ts` was not failing due to the expected object having keys in the wrong order. The first commit here fixes that.

The issue here appears to be that the key I was testing with contained a `.`, which is also the separator being used. This highlights an issue with the way the order-map is constructed. If any key ever contains the separator, then that key is not going to be included in the final object. Perhaps the solution here is to structure the order-map like an actual object, thereby alleviating the need for a separator:

```
{
  key1: [ "key1a", "key1b" ],
  key2: {
    key2a: [ "key2a1", ... ],
    key2b: {
      key2b1: ...
    }
  }
}
```